### PR TITLE
Please make proxying airshipd through a web server easier.

### DIFF
--- a/airship/static/airship.js
+++ b/airship/static/airship.js
@@ -1,6 +1,7 @@
-function Groundstation() {
+function Groundstation(prefix) {
+  this.prefix = prefix;
   this.channels = new Channels();
-  this.channels.url = '/channels';
+  this.channels.url = prefix + 'channels';
 
   this.active_grefs = new Grefs();
 
@@ -102,7 +103,7 @@ var GrefMenuItem = Backbone.View.extend({
   template: '<a class="select" href="#">{{identifier}}</a>',
 
   getUrl: function() {
-    return "/gref/" + this.model.attributes["channel"] + "/" + this.model.attributes["identifier"];
+    return groundstation.prefix + "gref/" + this.model.attributes["channel"] + "/" + this.model.attributes["identifier"];
   },
 
   render: function() {

--- a/airship/templates/index.html
+++ b/airship/templates/index.html
@@ -14,7 +14,8 @@
     <link rel="stylesheet" href="/static/groundstation.css">
     <title>airship.js</title>
     <script>
-      var groundstation = new Groundstation();
+      var root = window.location.pathname;
+      var groundstation = new Groundstation(root);
       $(document).ready(function() {
         groundstation.channels.reset({{channels_json|safe}});
         init_airship(groundstation);


### PR DESCRIPTION
airshipd can be evoked in such a way as to control the IP addresses it monitors for connections to port 9005/tcp (vis a vis, the --host command line option).  However, in environments where the IP address of the server cannot be predicted in advance this poses certain problems when setting up hyperlinks to airshipd.

Specifically, while it is possible to configure a web server to proxy airshipd into the URI space of a website (https://github.com/Byzantium/Byzantium/blob/master/porteus/apache/etc/httpd/extra/proxy-html.conf#L101) functionality is incomplete due to the manner in which /grefs/ links are generated.

127.0.0.1 - - [22/Jun/2013:21:41:08 +0000] "GET /Byzantium HTTP/1.1" 404 207
...
127.0.0.1 - - [22/Jun/2013:20:23:28 +0000] "GET /grefs/Byzantium HTTP/1.1" 404 213

The drop-down list of channels appears, but no message threads or messages appear.  Several days' worth of work and tinkering with airship.js has been fruitless, and frankly I'm not sure where to go from here.

My request is for advice or additional functionality which would make proxying airshipd through Apache easier to accomplish.  I'm not certain what form this would or should take at this time.
