### PR TITLE
Automatic refresh of gref pages.

### DIFF
--- a/airship/static/airship.js
+++ b/airship/static/airship.js
@@ -2,6 +2,8 @@ function Groundstation() {
   this.channels = new Channels();
   this.channels.url = '/channels';
 
+  this.current_channel = undefined;
+
   this.active_grefs = new Grefs();
 
   this.username = localStorage.getItem("airship.committer") || "Anonymous Coward";
@@ -85,6 +87,7 @@ function init_airship(groundstation) {
       alert("Validation failed!");
     }
   });
+  start_updater();
 }
 
 var Channel = Backbone.Model.extend();
@@ -98,6 +101,21 @@ var Grefs = Backbone.Collection.extend({
   model: Gref
 });
 
+function start_updater() {
+  var chk = $("#gref-autoupdate");
+  function update() {
+    if (chk.is(":checked")) {
+      if (groundstation.current_channel !== undefined) {
+        activate_channel(groundstation.current_channel, function() {
+          window.setTimeout(update, 5000);
+        });
+      }
+    } else {
+      window.setTimeout(update, 5000);
+    }
+  }
+  update();
+}
 
 var GrefMenuItem = Backbone.View.extend({
   tagName: "li",
@@ -141,8 +159,9 @@ var GrefMenuItem = Backbone.View.extend({
   }
 });
 
-function activate_channel(model) {
+function activate_channel(model, callback) {
     var current_grefs = $("#current-grefs")[0];
+    groundstation.current_channel = model;
     groundstation.active_grefs.url = '/grefs/' + model.attributes["name"];
     groundstation.active_grefs.redraw = function() {
       groundstation.active_grefs.fetch({
@@ -159,6 +178,9 @@ function activate_channel(model) {
       });
     };
     groundstation.active_grefs.redraw();
+    if (callback !== undefined) {
+      callback();
+    }
 }
 
 var visible_grefs = [];

--- a/airship/templates/index.html
+++ b/airship/templates/index.html
@@ -52,7 +52,7 @@
       <div class="span3">
         <div class="sidebar-nav">
           <ul class="nav nav-list" style="text-shadow: none;" id="current-grefs">
-            <li class="nav-header">grefs<span class="pull-right"><a id="new-gref">New</a></span></li>
+              <li class="nav-header">grefs<span class="pull-right"><input id="gref-autoupdate" type="checkbox"><label for="gref-autoupdate">autoupdate</label></input><a id="new-gref">New</a></span></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Groundstation currently does not automatically refresh displayed grefs.  To put it another way, users have to click on another gref and then back to the one they were just on to see new posts to that thead.  It'd be nice if displayed grefs automatically refreshed themselves a few seconds after somebody's posted a reply.
